### PR TITLE
Remove use of deprecated ActiveSupport::Memoizable

### DIFF
--- a/lib/api_guides/document.rb
+++ b/lib/api_guides/document.rb
@@ -1,7 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-require 'active_support/core_ext/object'
-
 module ApiGuides
   # The document class models the raw information in each guide.
   #
@@ -84,9 +82,6 @@ module ApiGuides
   # left-aligned so code and other indentation senstive markdown will be
   # parsed correctly.
   class Document
-    # Use ActiveSupport to memoize parsing methods
-    extend ActiveSupport::Memoizable
-
     attr_accessor :title, :position, :sections
 
     def initialize(attributes = {})

--- a/lib/api_guides/generator.rb
+++ b/lib/api_guides/generator.rb
@@ -52,8 +52,6 @@ module ApiGuides
   #
   #     generator.generate
   class Generator
-    extend ActiveSupport::Memoizable
-
     attr_accessor :source_path, :site_path, :default, :title, :logo
 
     # You can instatiate a new generator by passing a hash of attributes
@@ -153,9 +151,7 @@ module ApiGuides
     # Loop all the document's sections and examples to see all the different
     # languages specified by this document.
     def languages
-      documents.collect(&:sections).flatten.collect(&:examples).flatten.map(&:language).compact.uniq
+      @languages ||= documents.collect(&:sections).flatten.collect(&:examples).flatten.map(&:language).compact.uniq
     end
-    # Store this calculation for later so we don't have to do this retarded loop again.
-    memoize :languages
   end
 end


### PR DESCRIPTION
Resubmitting PR#3 because github got confused.

The ActiveSupport::Memoizable module is deprecated in ActiveSupport 3.2, so this just cleans up the warnings that running the doc generator emits during load.

It didn't seem like it was actually being used in ApiGuides::Document.

For the memoization in ApiGuides::Generator, the output of that pipeline shouldn't be nil, so the memoization there is really cheap and dirty.
